### PR TITLE
add new maintainers

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,8 @@ limitations under the License.
   <author email="xiaojun.huang@intel.com">Xiaojun Huang</author>
   <maintainer email="xiaojun.huang@intel.com">Xiaojun Huang</maintainer>
   <maintainer email="chao1.li@intel.com">Chao Li</maintainer>
-
+  <maintainer email="wei.zhi.liu@intel.com">Weizhi Liu</maintainer>
+  <maintainer email="jiawei.wu@intel.com">Jiawei Wu</maintainer>
   <license>Apache 2.0</license>
 
   <!-- <url type="website">http://wiki.ros.org/movidius_ncs</url> -->


### PR DESCRIPTION
Add new maintainers Weizhi Liu (wei.zhi.liu@intel.com) and Jiawei Wu (jiawei.wu@intel.com) for object_msgs package sub-release to other ROS versions.